### PR TITLE
fix typo in graphnet.py

### DIFF
--- a/communitynet/graphnet.py
+++ b/communitynet/graphnet.py
@@ -43,7 +43,7 @@ class GraphNet(nn.Module):
 
             edge_net = MLP(**{
                 **{
-                    "in_channels": num_edge_feats,
+                    "in_channels": num_edge_features,
                     "out_channels": in_channels * out_channels
                 },
                 **edge_nn_kwargs


### PR DESCRIPTION
there is no parameter named **num_edge_feats**, i think it's the typo of **num_edge_features**.